### PR TITLE
Issue 45: Use keras tokenizer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setup(
         'pandas',
         'sklearn',
         'tensorflow==2.0',
-        'click'
+        'click',
+        'keras'
     ],
     test_suite='nose.collector',
     tests_require=test_deps,

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,7 @@ setup(
         'pandas',
         'sklearn',
         'tensorflow==2.0',
-        'click',
-        'keras'
+        'click'
     ],
     test_suite='nose.collector',
     tests_require=test_deps,

--- a/tests/test_n2v.py
+++ b/tests/test_n2v.py
@@ -311,7 +311,7 @@ class TestStringInteraction(TestCase):
             print("{} was previously downloaded".format(local_file))
 
         encoder = TextEncoder(local_file)
-        data, count, dictionary, reverse_dictionary = encoder.build_dataset()
+        data, count, dictionary, reverse_dictionary = encoder.build_dataset_with_keras()
         model = SkipGramWord2Vec(
             data, worddictionary=dictionary, reverse_worddictionary=reverse_dictionary)
         model.add_display_words(count)

--- a/tests/test_text_encoder.py
+++ b/tests/test_text_encoder.py
@@ -37,7 +37,7 @@ class TestTextEncoderEnBlock(TestCase):
     def setUp(self):
         infile = os.path.join(os.path.dirname(__file__), 'data', 'greatExpectations3.txt')
         encoder = TextEncoder(infile)
-        data, count, dictionary, reverse_dictionary = encoder.build_dataset()
+        data, count, dictionary, reverse_dictionary = encoder.build_dataset_with_keras()
         self.data = data
         self.count = count
         self.dictionary = dictionary

--- a/xn2v/text_encoder.py
+++ b/xn2v/text_encoder.py
@@ -6,9 +6,8 @@ import bz2
 
 from math import ceil
 
-from keras.preprocessing.text import text_to_word_sequence
-from keras_preprocessing.text import Tokenizer
 from pandas.core.common import flatten
+from tensorflow.keras.preprocessing.text import text_to_word_sequence, Tokenizer
 
 
 class TextEncoder:

--- a/xn2v/text_encoder.py
+++ b/xn2v/text_encoder.py
@@ -6,6 +6,10 @@ import bz2
 
 from math import ceil
 
+from keras.preprocessing.text import text_to_word_sequence
+from keras_preprocessing.text import Tokenizer
+from pandas.core.common import flatten
+
 
 class TextEncoder:
     """
@@ -100,7 +104,6 @@ class TextEncoder:
             for i in range(ceil(file_size // chunk_size) + 1):
                 bytes_to_read = min(chunk_size, file_size - (i * chunk_size))
                 file_string = file.read(bytes_to_read).decode('utf-8')
-
                 # lowercase and tokenize into list of words
                 data.extend(file_string.lower().split())
 
@@ -260,3 +263,50 @@ class TextEncoder:
         # log.info('Most common words (+UNK) {}', str(count[:5)])
         # log.info('Sample data: {}', str(data[:10]))
         return data, count, dictionary, dict(zip(dictionary.values(), dictionary.keys()))
+
+
+    def build_dataset_with_keras(self, max_vocab_size=50000):
+        text = self.get_raw_text()
+        words = text_to_word_sequence(text, lower=True, filters='\'!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n')
+        words = self.remove_stopwords(words)
+        max_vocab_size = min(max_vocab_size, len(set(words)))
+        print("Max vocab size: {}".format(max_vocab_size))
+        # initialize Tokenizer with 'UNK' as the out-of-vocabulary token.
+        # Since Keras reserves the 0th index for padding sequences, the index for 'UNK'
+        # will be 1st index
+        # max_vocab_size + 1 because Keras reserves the 0th index
+        tokenizer = Tokenizer(num_words=max_vocab_size + 1, oov_token='UNK', lower=True, filters='\'!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n')
+        sentences = self.parse_file_into_sentences()
+        tokenizer.fit_on_texts(sentences)
+        sequences = tokenizer.texts_to_sequences(sentences)
+        # for downstream compatibility
+        flatted_sequences = list(flatten(sequences))
+        dictionary = tokenizer.word_index
+        reverse_dictionary = dict(zip(dictionary.values(), dictionary.keys()))
+        count = tokenizer.word_counts
+        # for downstream compatibility
+        count_as_tuples = list(zip(list(count.keys()), list(count.values())))
+
+        return flatted_sequences, count_as_tuples, dictionary, reverse_dictionary
+
+    def get_raw_text(self):
+        text = open(self.filename).read()
+        return text
+
+    def parse_file_into_sentences(self):
+        sentences = []
+
+        with open(self.filename) as file:
+            print('Reading data from {filename}'.format(filename=self.filename))
+            for line in file:
+                # calling clean_text since Keras does not undo contractions
+                cleaned_line = self.clean_text(line)
+                # removing stopwords since Keras does not support removing a defined set of words
+                cleaned_line = self.remove_stopwords(cleaned_line.split(' '))
+                sentences.append(' '.join(cleaned_line))
+        return sentences
+
+    def remove_stopwords(self, words):
+        filtered_words = []
+        filtered_words.extend([word for word in words if word not in self.stopwords])
+        return filtered_words


### PR DESCRIPTION
This PR uses `keras_preprocessing.text.Tokenizer` for building the datasets.

Although, the `test_n2v.py` test is failing in two scenarios:

1. Running into an invalid argument error:
```
E   tensorflow.python.framework.errors_impl.InvalidArgumentError: indices[42] = 10387 is not in [0, 10387) [Op:ResourceGather] name: embedding_lookup/

<string>:3: InvalidArgumentError

```

I am not sure why and was wondering if @pnrobinson @callahantiff @vidarmehr have seen this before? 

2. Running into an issue (at random) when index 0 is used for display_examples in Word2Vec

```
self = <xn2v.word2vec.SkipGramWord2Vec object at 0x13a7b8b38>, display_step = 1000

    def train(self, display_step=2000):
        # Words for testing.
        # display_step = 2000
        # eval_step = 2000
        if display_step is not None:
            for w in self.display_examples:
>               print("{}: id={}".format(self.id2word[w], w))
E               KeyError: 0

xn2v/word2vec.py:407: KeyError
```

The above is because the index 0 is reserved in Keras and thus the dictionary generated by Keras Tokenizer will never have a lookup for index 0. 

Not sure how to fix this without modifying the random sampling of words in Word2Vec.