### PR TITLE
neighbors_as_ints was added in csf_graph.py 

### DIFF
--- a/tests/test_csf_graph.py
+++ b/tests/test_csf_graph.py
@@ -24,7 +24,7 @@ class TestCSFGraph(TestCase):
         self.g.print_edge_type_distribution()
 
     def test_count_nodes(self):
-        # The graphh in small_graph.txt has 11 nodes
+        # The graph in small_graph.txt has 11 nodes
         expected_num = 11
         self.assertEqual(expected_num, self.g.node_count())
 
@@ -44,10 +44,17 @@ class TestCSFGraph(TestCase):
         self.assertEqual(expected, weight)
 
     def test_get_neighbors1(self):
-        # The neighhbors of p4 are g4, p2, p3
+        # The neighbors of p4 are g4, p2, p3
         nbrs = self.g.neighbors('p4')
         # print(nbrs)
         self.assertEqual(['g4', 'p2', 'p3'], nbrs)
+
+    def test_get_neighbors_as_ints_1(self):
+        # The neighbors of p4 are g4, p2, p3
+        nbrs = self.g.neighbors_as_ints('p4')
+        #print("index of g4 = {}, index of p2 = {}, index of p3 = {}".
+              #format(self.g.node_to_index_map['g4'], self.g.node_to_index_map['p2'],self.g.node_to_index_map['p3']))
+        self.assertEqual([6, 8, 9], nbrs)
 
     def test_nodes_as_integers(self):
         self.g.nodes_as_integers()
@@ -57,6 +64,14 @@ class TestCSFGraph(TestCase):
         nbrs = self.g.neighbors('g2')
         # print(nbrs)
         self.assertEqual(['g1', 'g3', 'p1', 'p2'], nbrs)
+
+    def test_get_neighbors_as_ints_2(self):
+        # The neighbors of g2 are g1, g3, p1, p2
+        nbrs = self.g.neighbors_as_ints('g2')
+        #print("index of g1 = {}, index of g3 = {}, index of p1 = {}, index of p2 = {}".
+        #format(self.g.node_to_index_map['g1'], self.g.node_to_index_map['g3'], self.g.node_to_index_map['p1'],
+        #self.g.node_to_index_map['p2']))
+        self.assertEqual([3, 5, 7, 8], nbrs)
 
     def test_check_nodetype(self):
         self.assertTrue(self.g.same_nodetype('g1', 'g2'))

--- a/xn2v/csf_graph/csf_graph.py
+++ b/xn2v/csf_graph/csf_graph.py
@@ -133,8 +133,8 @@ class CSFGraph:
 
     def neighbors(self, source):
         """
-        :param source: index (integer) of source node
-        :return: list of indices of neighbors
+        :param source: source node
+        :return: list of neighbors of source
         """
         nbrs = []
         source_idx = self.node_to_index_map[source]
@@ -142,6 +142,18 @@ class CSFGraph:
             nbr = self.index_to_node_map[self.edge_to[i]]
             nbrs.append(nbr)
         return nbrs
+
+    def neighbors_as_ints(self, source):
+        """
+        :param source: source node
+        :return: list of indices of neighbors of source
+        """
+        nbrs_ints = []
+        source_idx = self.node_to_index_map[source]
+        for i in range(self.offset_to_edge_[source_idx], self.offset_to_edge_[source_idx + 1]):
+            nbr = self.edge_to[i]
+            nbrs_ints.append(nbr)
+        return nbrs_ints
 
     def has_edge(self, src, dest):
         """


### PR DESCRIPTION
This method returns a list of indices of neighbors of a node. The method has been tested in test_get_neighbors_as_ints_1 and test_get_neighbors_as_ints_2 in test_csf_graph.