### PR TITLE
add cosine similarity score of two vectors with tensorflow and tests

### DIFF
--- a/tests/test_link_prediction_functions.py
+++ b/tests/test_link_prediction_functions.py
@@ -218,7 +218,8 @@ class TestlinkPredictionScores_2(TestCase):
 
 class TestCosieSimilarity(TestCase):
     """
-    Test the cosine similarity of two vectors.
+    Test the cosine similarity of two vectors. The first 3 tests calculate cos_sim between two vectors
+    without tensorflow. The last 3 tests use tensorflow library to calculate cos_sim.
     """
     def test_cos_sim_1(self):
         X = np.array([1,2])
@@ -241,5 +242,33 @@ class TestCosieSimilarity(TestCase):
         Y = np.array([3,4,0])
         cos_sim = link_prediction_functions.cosine_similarity(X, Y)
         # <X,Y> = 1*3 =3
-        # sqrt(<X,X>)= 1, sqrt(<Y,Y>)= sqrt(9+16)=5. Thus cos_sim= 1/5
+        # sqrt(<X,X>)= 1, sqrt(<Y,Y>)= sqrt(9+16)=5. Thus cos_sim= 3/5
         self.assertEqual(3.0/5.0, cos_sim)
+
+
+    def test_cos_sim_tf_1(self):
+        X = np.array([1,2])
+        Y = np.array([3,4])
+        cos_sim = link_prediction_functions.cosine_similarity_tf(X, Y)
+        #<X,Y> = 1*3 + 2*4 = 11
+        #sqrt(<X,X>)= sqrt(1+4), sqrt(<Y,Y>)= sqrt(9+16)=5. Thus cos_sim= 11/ 5*sqrt(5)
+        estimate = round(11/(5*math.sqrt(5)), 7)#round the number to 7 decimals
+        self.assertAlmostEqual(estimate, cos_sim)
+
+    def test_cos_sim_tf_2(self):
+        X = np.array([1,2,0])
+        Y = np.array([3,4,1])
+        cos_sim = link_prediction_functions.cosine_similarity_tf(X, Y)
+        # <X,Y> = 1*3 + 2*4 + 0*1 = 11
+        # sqrt(<X,X>)= sqrt(1+4), sqrt(<Y,Y>)= sqrt(9+16+1)=sqrt(26). Thus cos_sim= 11/ sqrt(26)*sqrt(5)
+        estimate = round(11.0/(math.sqrt(26)*math.sqrt(5)), 7)#round the number to 7 decimals
+        self.assertAlmostEqual(estimate, cos_sim)
+
+
+    def test_cos_sim_tf_3(self):
+        X = np.array([1, 0, 0])
+        Y = np.array([3, 4, 0])
+        cos_sim = link_prediction_functions.cosine_similarity_tf(X,Y)
+        # <X,Y> = 1*3 =3
+        # sqrt(<X,X>)= 1, sqrt(<Y,Y>)= sqrt(9+16)=5. Thus cos_sim= 3/5=0.6
+        self.assertAlmostEqual(0.6, cos_sim)

--- a/tests/test_link_prediction_functions.py
+++ b/tests/test_link_prediction_functions.py
@@ -217,35 +217,9 @@ class TestlinkPredictionScores_2(TestCase):
         self.assertAlmostEqual(1.0/np.log(102.0), score)
 
 class TestCosieSimilarity(TestCase):
-    """
-    Test the cosine similarity of two vectors. The first 3 tests calculate cos_sim between two vectors
-    without tensorflow. The last 3 tests use tensorflow library to calculate cos_sim.
-    """
-    def test_cos_sim_1(self):
-        X = np.array([1,2])
-        Y = np.array([3,4])
-        cos_sim = link_prediction_functions.cosine_similarity(X, Y)
-        #<X,Y> = 1*3 + 2*4 = 11
-        #sqrt(<X,X>)= sqrt(1+4), sqrt(<Y,Y>)= sqrt(9+16)=5. Thus cos_sim= 11/ 5*sqrt(5)
-        self.assertEqual(11/(5*math.sqrt(5)), cos_sim)
-
-    def test_cos_sim_2(self):
-        X = np.array([1,2,0])
-        Y = np.array([3,4,1])
-        cos_sim = link_prediction_functions.cosine_similarity(X, Y)
-        # <X,Y> = 1*3 + 2*4 + 0*1 = 11
-        # sqrt(<X,X>)= sqrt(1+4), sqrt(<Y,Y>)= sqrt(9+16+1)=sqrt(26). Thus cos_sim= 11/ sqrt(26)*sqrt(5)
-        self.assertEqual(11/(math.sqrt(26)*math.sqrt(5)), cos_sim)
-
-    def test_cos_sim_3(self):
-        X = np.array([1,0,0])
-        Y = np.array([3,4,0])
-        cos_sim = link_prediction_functions.cosine_similarity(X, Y)
-        # <X,Y> = 1*3 =3
-        # sqrt(<X,X>)= 1, sqrt(<Y,Y>)= sqrt(9+16)=5. Thus cos_sim= 3/5
-        self.assertEqual(3.0/5.0, cos_sim)
-
-
+    #
+    #Test the cosine similarity of two vectors using tensorflow.
+    #
     def test_cos_sim_tf_1(self):
         X = np.array([1,2])
         Y = np.array([3,4])

--- a/xn2v/link_prediction_functions.py
+++ b/xn2v/link_prediction_functions.py
@@ -5,15 +5,14 @@
 ###
 
 import numpy as np  # type: ignore
-import sklearn  # type: ignore
-
+import tensorflow as tf
 def DegreeProduct(graph, node_1, node_2):
     ''' Function takes a CSF graph object and list of edges calculates the Degree Product or Preferential Attachment for these
     nodes given the structure of the graph.
     :param graph: CSFgraph  object
     :param node_1: one node of graph
     :param node_2: one node of a graph
-    :return: Degree Productscore of the nodes
+    :return: Degree Product score of the nodes
     '''
 
     score = (graph.node_degree(node_1) * graph.node_degree(node_2))
@@ -114,3 +113,12 @@ def cosine_similarity(emb_1,emb_2):
     denominator = np.sqrt(emb_1.dot(emb_1)) * np.sqrt(emb_2.dot(emb_2))
     similarity_score = nominator / denominator
     return similarity_score
+
+
+def cosine_similarity_tf(emb1, emb2):
+    # cosin_similarity of two vectors X and Y with tensorflow:
+    # cosine similarity = <X,Y> / ||X||||Y|| where <X,Y> is the dot product and ||X|| is sqrt(<X,X>)
+    m = tf.keras.metrics.CosineSimilarity(name='cosine_similarity', dtype=None, axis=-1)
+    m.update_state(emb1, emb2)
+    return m.result().numpy()
+

--- a/xn2v/link_prediction_functions.py
+++ b/xn2v/link_prediction_functions.py
@@ -106,14 +106,6 @@ def AdamicAdar(graph, node_1, node_2):
     #return sorted_ind, valid_words
 
 
-def cosine_similarity(emb_1,emb_2):
-    #cosin_similarity of two vectors X and Y = <X,Y> / ||X||||Y|| where <X,Y> is the dot product
-    #and ||X|| is sqrt(<X,X>)
-    nominator = np.dot(emb_1,emb_2)
-    denominator = np.sqrt(emb_1.dot(emb_1)) * np.sqrt(emb_2.dot(emb_2))
-    similarity_score = nominator / denominator
-    return similarity_score
-
 
 def cosine_similarity_tf(emb1, emb2):
     # cosin_similarity of two vectors X and Y with tensorflow:


### PR DESCRIPTION
@pnrobinson Peter, I have added tensorflow implementation of cosine similarity between two vectors. The code is cosine_similarity_tf(emb1, emb2) in link_prediction_functions.py. I have still kept my own code for calculating cosine similarity (without tf). There are also some tests in test_link_prediction_functions to test link prediction functions including cosine similarity scores. Could you please take a look at it and approve pull request if you think it is ok? Thanks.