### PR TITLE
Add caching of random walks in N2vGraph

### DIFF
--- a/runLinkPrediction_ppi.py
+++ b/runLinkPrediction_ppi.py
@@ -6,7 +6,7 @@ from xn2v.word2vec import SkipGramWord2Vec
 from xn2v.word2vec import ContinuousBagOfWordsWord2Vec
 from xn2v import LinkPrediction
 import xn2v
-from xn2v.utils import write_embeddings
+from xn2v.utils import write_embeddings, serialize, deserialize
 import sys
 
 
@@ -89,6 +89,19 @@ def parse_args():
     parser.add_argument('--num_steps', type=int, default=100000,
                         help='number of steps for GD.  Default is 100000.')
 
+    parser.add_argument('--random_walks', type=str,
+                        help='Use a cached version of random walks. \
+                        (Note: This assumes that --pos_train is the same as the one used to build the cached version)')
+
+    parser.add_argument('--cache_random_walks', action='store_true',
+                        help='Cache the random walks generated from pos_train CsfGraph. \
+                        (--random_walks argument must be defined)')
+
+    parser.add_argument('--use_cache_random_walks', action='store_true',
+                        help='Use the cached version of random walks. \
+                        (--random_walks argument must be defined)\
+                        (Note: This assumes that --pos_train is the same as the one used to build the cached version)')
+
     return parser.parse_args()
 
 
@@ -169,8 +182,21 @@ def main(args):
             .format(args.p, args.q, args.classifier, args.useGamma, args.w2v_model, args.num_steps, args.skip_window,
                     args.embedding_size))
     pos_train_graph, pos_test_graph, neg_train_graph, neg_test_graph = read_graphs()
-    pos_train_g = N2vGraph(pos_train_graph, args.p, args.q, args.gamma, args.useGamma)
-    walks = pos_train_g.simulate_walks(args.num_walks, args.walk_length)
+    if args.use_cache_random_walks and args.random_walks:
+        # restore post_train_g from cache
+        print(f"Restore random walks from {args.random_walks}")
+        pos_train_g = deserialize(args.random_walks)
+    else:
+        # generate pos_train_g and simulate walks
+        pos_train_g = N2vGraph(pos_train_graph, args.p, args.q, args.gamma, args.useGamma)
+
+    pos_train_g.simulate_walks(args.num_walks, args.walk_length, args.use_cache_random_walks)
+
+    if args.cache_random_walks and args.random_walks:
+        print(f"Caching random walks to {args.random_walks}")
+        serialize(pos_train_g, args.random_walks)
+
+    walks = pos_train_g.random_walks_map[(args.num_walks, args.walk_length)]
     learn_embeddings(walks, pos_train_graph, args.w2v_model)
     linkpred(pos_train_graph, pos_test_graph, neg_train_graph, neg_test_graph)
 

--- a/tests/test_hetnode2vec_tf.py
+++ b/tests/test_hetnode2vec_tf.py
@@ -6,6 +6,8 @@ from xn2v.hetnode2vec import N2vGraph
 from tests.utils.utils import calculate_total_probs
 from parameterized import parameterized
 
+from xn2v.utils import serialize, deserialize
+
 
 class TestGraph(TestCase):
 
@@ -423,3 +425,74 @@ class TestHetGraph2(TestCase):
         # p1 has g1 as a neighbor in different network and has 29 protein neighbors in the same network.
         # The probability of going  to p2 is (1-gamma/2)/29 which is (5/(6*29))
         self.assertAlmostEqual(5.0 / 174.0, p2prob)
+
+
+class TestGraphCache(TestCase):
+
+    def setUp(self):
+        data_dir = os.path.join(os.path.dirname(__file__), 'data')
+
+        # these pass the tests okay
+        node_file = os.path.join(data_dir, 'small_graph_nodes.tsv')
+        edge_file = os.path.join(data_dir, 'small_graph_edges.tsv')
+
+        g = CSFGraph(edge_file=edge_file, node_file=node_file)
+        self.graph = g
+
+    def test_caching(self):
+        """
+        Test caching of random walks in N2vGraph by,
+            - creating the N2vGraph
+            - running simulate_walks and storing the walks as a property of N2vGraph
+        """
+        p = 1
+        q = 1
+        gamma = 1
+        num_walks = 10
+        walk_length = 1
+        g = N2vGraph(self.graph, p, q, gamma)
+        g.simulate_walks(num_walks, walk_length)
+        assert len(g.random_walks_map) > 0
+
+    def test_caching_restore(self):
+        """
+        Test caching of random walks in N2vGraph by,
+            - creating the N2vGraph
+            - running simulate_walks and storing the walks as a property of N2vGraph
+            - restoring the exact same walk for the same num_walks and walk_length
+        """
+        p = 1
+        q = 1
+        gamma = 1
+        num_walks = 10
+        walk_length = 1
+        g = N2vGraph(self.graph, p, q, gamma)
+        walks1 = g.simulate_walks(num_walks, walk_length)
+        walks2 = g.simulate_walks(num_walks, walk_length, use_cache=True)
+        # Expected: walks2 should be retrieved from cache since use_cache is True
+        assert walks1 == walks2
+        walks3 = g.simulate_walks(num_walks, walk_length, use_cache=False)
+        # Expected: walks3 should be a newly randomized walk
+        # and should not match with walks1
+        assert walks1 != walks3
+
+    def test_cache_graph_state(self):
+        """
+        Test caching of N2vGraph state into a pickle.
+        """
+        p = 1
+        q = 1
+        gamma = 1
+        num_walks = 10
+        walk_length = 1
+        g = N2vGraph(self.graph, p, q, gamma)
+        walks1 = g.simulate_walks(num_walks, walk_length)
+        serialize(g, 'N2vGraph.pkl')
+
+    def test_cache_graph_state_restore(self):
+        """
+        Test restore of N2vGraph state from a pickle.
+        """
+        g = deserialize('N2vGraph.pkl')
+        k = (10, 1)
+        assert k in g.random_walks_map.keys()

--- a/xn2v/utils/embedding_utils.py
+++ b/xn2v/utils/embedding_utils.py
@@ -13,12 +13,14 @@ Reads and Writes Embedding Data
 """
 
 # import needed libraries
+import pickle
+
 import numpy as np  # type: ignore
 import os
 import os.path
 import tensorflow as tf  # type: ignore
 
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Any
 
 
 # TODO: consider updating writes_embeddings to not require id2word when writing embedding data
@@ -138,3 +140,36 @@ def load_embeddings(file_name: str) -> Dict[str, List[float]]:
         print('Finished ingesting {} lines (vectors) from {}'.format(n_lines, file_name))
 
     return embedding_data
+
+
+def serialize(obj: Any, filename: str) -> None:
+    """Serialize an object into a pickle and store into a file.
+
+    Args:
+        obj: The object to serialize
+        filename: The filename to write the pickle to
+
+    """
+    try:
+        FH = open(filename, 'wb')
+        pickle.dump(obj, FH)
+    except FileNotFoundError:
+        print(f"File {filename} not found")
+
+
+def deserialize(filename: str) -> Any:
+    """Deserialize an object from a pickle.
+
+    Args:
+        filename: The filename to read the pickle from
+
+    Returns:
+        The object
+
+    """
+    try:
+        FH = open(filename, 'rb')
+        obj = pickle.load(FH)
+        return obj
+    except FileNotFoundError:
+        print(f"File {filename} not found")


### PR DESCRIPTION
This PR adds the following,
- the ability to cache random walks in N2vGraph for a given `num_walks` and `walk_length`
- the ability to store the state of N2vGraph itself at runtime
- the ability to restore the state of N2vGraph from a previous run

Few considerations made while working on this PR,
- the random walks generated by `N2vGraph.simulate_walks` are dependent on the state of N2vGraph since it relies on the attached csf_graph, p, q and gamma. Thus, for caching, the random walks are stored as a property of N2vGraph
- This does not mean that the method signature of `N2vGraph.simulate_walks` has changed. It would still return a new walk each time. It would rely on the cache if and only if `use_cache` argument is `True` and there was a previous call made to this method for the same `num_walks` and `walk_length`.
- caching can be troublesome at times, especially when done implicitly. To avoid this issue the caching behavior in N2vGraph is implemented in such a way that it will have to be invoked explicitly.


@vidarmehr I updated `runLinkPrediction_ppi.py` and `runLinkPrediction_with_validation_ppi.py` with arguments that allow for storing the state of the N2vGraph as a pickle or restoring the state of N2vGraph from a previously generated pickle.

To store the state of N2vGraph,
```
python runLinkPrediction_ppi.py --p 2 --num_steps 10000 --embedding_size 100 
--w2v_model CBOW --random_walks walks.pkl --cache_random_walks --num-walks 10
```

To restore the state of N2vGraph,
```
python runLinkPrediction_ppi.py --p 2 --num_steps 10000 --embedding_size 100 
--w2v-model CBOW --random_walks walks.pkl --use_cache_random_walks --num-walks 10
```

As a side note: could we perhaps rename `N2vGraph` to `RandomWalks` or `RandomWalksGenerator` since this class is tasked with generating walks or performing computations relevant for performing random walks.